### PR TITLE
Improve support for fk fields

### DIFF
--- a/fastapi_admin/resources.py
+++ b/fastapi_admin/resources.py
@@ -294,6 +294,15 @@ class Model(Resource):
                 ret.append(field)
         return ret
 
+    @classmethod
+    def get_fk_field(cls):
+        ret = []
+        for field in cls.fields or cls.model._meta.fields:
+            if isinstance(field, Field):
+                field = field.name
+            if field in cls.model._meta.fk_fields:
+                ret.append(field)
+        return ret
 
 class Dropdown(Resource):
     resources: List[Type[Resource]]

--- a/fastapi_admin/resources.py
+++ b/fastapi_admin/resources.py
@@ -134,7 +134,11 @@ class Model(Resource):
                 continue
             if isinstance(input_, inputs.File):
                 cls.enctype = "multipart/form-data"
-            if isinstance(input_, inputs.ForeignKey) and name in obj._meta.fk_fields:
+            if (
+                isinstance(input_, inputs.ForeignKey)
+                and (obj is not None)
+                and name in obj._meta.fk_fields
+            ):
                 await obj.fetch_related(name)
                 # Value must be the string representation of the fk obj 
                 value = str(getattr(obj, name, None))

--- a/fastapi_admin/resources.py
+++ b/fastapi_admin/resources.py
@@ -159,6 +159,11 @@ class Model(Resource):
             if input_.context.get("disabled") or isinstance(input_, inputs.DisplayOnly):
                 continue
             name = input_.context.get("name")
+            if isinstance(input_, inputs.ForeignKey):
+                v = data.getlist(name)[0]
+                model = await input_.model.get(id=v)
+                ret[name] = model
+                continue
             if isinstance(input_, inputs.ManyToMany):
                 v = data.getlist(name)
                 value = await input_.parse_value(request, v)

--- a/fastapi_admin/routes/resources.py
+++ b/fastapi_admin/routes/resources.py
@@ -86,13 +86,14 @@ async def update(
 ):
     form = await request.form()
     data, m2m_data = await model_resource.resolve_data(request, form)
+    m2m_fields = model_resource.get_m2m_field()
     async with in_transaction() as conn:
         obj = (
             await model.filter(pk=pk)
             .using_db(conn)
             .select_for_update()
             .get()
-            .prefetch_related(*model_resource.get_m2m_field())
+            .prefetch_related(*m2m_fields)
         )
         await obj.update_from_dict(data).save(using_db=conn)
         for k, items in m2m_data.items():
@@ -105,7 +106,7 @@ async def update(
             .using_db(conn)
             .select_related(*model_resource.get_fk_field())
             .get()
-            .prefetch_related(*model_resource.get_m2m_field())
+            .prefetch_related(*m2m_fields)
         )
     inputs = await model_resource.get_inputs(request, obj)
     if "save" in form.keys():

--- a/fastapi_admin/routes/resources.py
+++ b/fastapi_admin/routes/resources.py
@@ -103,6 +103,7 @@ async def update(
         obj = (
             await model.filter(pk=pk)
             .using_db(conn)
+            .select_related(*model_resource.get_fk_field())
             .get()
             .prefetch_related(*model_resource.get_m2m_field())
         )

--- a/fastapi_admin/templates/widgets/inputs/select.html
+++ b/fastapi_admin/templates/widgets/inputs/select.html
@@ -3,7 +3,7 @@
         <div class="form-label">{{ label }}</div>
         <select class="form-select" name="{{ name }}" id="{{ id }}">
             {% for option in options %}
-                <option value="{{ option[1] }}" {% if option[1] == value %}
+                <option value="{{ option[1] }}" {% if option[0] == value %}
                         selected
                 {% endif %} >{{ option[0] }}</option>
             {% endfor %}


### PR DESCRIPTION
Fix https://github.com/fastapi-admin/fastapi-admin/issues/89

It allows update foreign-key relations following a similar logic implemented with m2m fields. It will render the same `obj.__str__()` value inside the dropdown menu