### PR TITLE
Ignore empty inputs if field isn't required

### DIFF
--- a/fastapi_admin/resources.py
+++ b/fastapi_admin/resources.py
@@ -294,6 +294,15 @@ class Model(Resource):
                 ret.append(field)
         return ret
 
+    @classmethod
+    def get_fk_field(cls):
+        ret = []
+        for field in cls.fields or cls.model._meta.fields:
+            if isinstance(field, Field):
+                field = field.name
+            if field in cls.model._meta.fk_fields:
+                ret.append(field)
+        return ret
 
 class Dropdown(Resource):
     resources: List[Type[Resource]]

--- a/fastapi_admin/resources.py
+++ b/fastapi_admin/resources.py
@@ -134,7 +134,11 @@ class Model(Resource):
                 continue
             if isinstance(input_, inputs.File):
                 cls.enctype = "multipart/form-data"
-            if isinstance(input_, inputs.ForeignKey) and name in obj._meta.fk_fields:
+            if (
+                isinstance(input_, inputs.ForeignKey)
+                and (obj is not None)
+                and name in obj._meta.fk_fields
+            ):
                 await obj.fetch_related(name)
                 # Value must be the string representation of the fk obj 
                 value = str(getattr(obj, name, None))

--- a/fastapi_admin/resources.py
+++ b/fastapi_admin/resources.py
@@ -169,6 +169,8 @@ class Model(Resource):
             if input_.context.get("disabled") or isinstance(input_, inputs.DisplayOnly):
                 continue
             name = input_.context.get("name")
+            if input_.context.get("null") and data.get(name) == "":
+                continue
             if isinstance(input_, inputs.ForeignKey):
                 v = data.getlist(name)[0]
                 model = await input_.model.get(id=v)

--- a/fastapi_admin/resources.py
+++ b/fastapi_admin/resources.py
@@ -159,6 +159,11 @@ class Model(Resource):
             if input_.context.get("disabled") or isinstance(input_, inputs.DisplayOnly):
                 continue
             name = input_.context.get("name")
+            if isinstance(input_, inputs.ForeignKey):
+                v = data.getlist(name)[0]
+                model = await input_.model.get(id=v)
+                ret[name] = model
+                continue
             if isinstance(input_, inputs.ManyToMany):
                 v = data.getlist(name)
                 value = await input_.parse_value(request, v)

--- a/fastapi_admin/routes/resources.py
+++ b/fastapi_admin/routes/resources.py
@@ -28,8 +28,11 @@ async def list_view(
 ):
     fields_label = model_resource.get_fields_label()
     fields = model_resource.get_fields()
+    fk_fields = model_resource.get_fk_field()
     qs = model.all()
-    params, qs = await model_resource.resolve_query_params(request, dict(request.query_params), qs)
+    params, qs = await model_resource.resolve_query_params(
+        request, dict(request.query_params), qs
+    )
     filters = await model_resource.get_filters(request, params)
     total = await qs.count()
     if page_size:
@@ -37,10 +40,23 @@ async def list_view(
     else:
         page_size = model_resource.page_size
     qs = qs.offset((page_num - 1) * page_size)
-    values = await qs.values()
-    rendered_values, row_attributes, column_attributes, cell_attributes = await render_values(
-        request, model_resource, fields, values
-    )
+    if fk_fields:
+        objects = await qs.select_related(*fk_fields)
+        values = []
+        for obj in objects:
+            obj_as_dict = dict(obj)
+            for attr in fk_fields:
+                obj_as_dict[attr] = getattr(obj, attr)
+            values.append(obj_as_dict)
+    else:
+        values = await qs.values()
+
+    (
+        rendered_values,
+        row_attributes,
+        column_attributes,
+        cell_attributes,
+    ) = await render_values(request, model_resource, fields, values)
     context = {
         "request": request,
         "resources": resources,
@@ -241,10 +257,14 @@ async def create(
 @router.delete("/{resource}/delete/{pk}")
 async def delete(request: Request, pk: str, model: Model = Depends(get_model)):
     await model.filter(pk=pk).delete()
-    return RedirectResponse(url=request.headers.get("referer"), status_code=HTTP_303_SEE_OTHER)
+    return RedirectResponse(
+        url=request.headers.get("referer"), status_code=HTTP_303_SEE_OTHER
+    )
 
 
 @router.delete("/{resource}/delete")
 async def bulk_delete(request: Request, ids: str, model: Model = Depends(get_model)):
     await model.filter(pk__in=ids.split(",")).delete()
-    return RedirectResponse(url=request.headers.get("referer"), status_code=HTTP_303_SEE_OTHER)
+    return RedirectResponse(
+        url=request.headers.get("referer"), status_code=HTTP_303_SEE_OTHER
+    )

--- a/fastapi_admin/routes/resources.py
+++ b/fastapi_admin/routes/resources.py
@@ -86,13 +86,14 @@ async def update(
 ):
     form = await request.form()
     data, m2m_data = await model_resource.resolve_data(request, form)
+    m2m_fields = model_resource.get_m2m_field()
     async with in_transaction() as conn:
         obj = (
             await model.filter(pk=pk)
             .using_db(conn)
             .select_for_update()
             .get()
-            .prefetch_related(*model_resource.get_m2m_field())
+            .prefetch_related(*m2m_fields)
         )
         await obj.update_from_dict(data).save(using_db=conn)
         for k, items in m2m_data.items():
@@ -105,7 +106,7 @@ async def update(
             .using_db(conn)
             .select_related(*model_resource.get_fk_field())
             .get()
-            .prefetch_related(*model_resource.get_m2m_field())
+            .prefetch_related(*m2m_fields)
         )
     inputs = await model_resource.get_inputs(request, obj)
     if "save" in form.keys():

--- a/fastapi_admin/routes/resources.py
+++ b/fastapi_admin/routes/resources.py
@@ -103,6 +103,7 @@ async def update(
         obj = (
             await model.filter(pk=pk)
             .using_db(conn)
+            .select_related(*model_resource.get_fk_field())
             .get()
             .prefetch_related(*model_resource.get_m2m_field())
         )

--- a/fastapi_admin/templates/widgets/inputs/select.html
+++ b/fastapi_admin/templates/widgets/inputs/select.html
@@ -3,7 +3,7 @@
         <div class="form-label">{{ label }}</div>
         <select class="form-select" name="{{ name }}" id="{{ id }}">
             {% for option in options %}
-                <option value="{{ option[1] }}" {% if option[1] == value %}
+                <option value="{{ option[1] }}" {% if option[0] == value %}
                         selected
                 {% endif %} >{{ option[0] }}</option>
             {% endfor %}


### PR DESCRIPTION
Currently, if a form field is not required and leaves it blank, it can raise an error if an empty value string (`""`) isn't valid, for example, a UUID field.

This PR fixes this issue by checking if the field is required and if not, checks if its value is empty. If the value is empty, the field is ignored.

We need to check what happens with other fields type, where the empty value can be another type than an empty string