### PR TITLE
Fix JSON input value serialization in template

### DIFF
--- a/fastapi_admin/templates/widgets/inputs/json.html
+++ b/fastapi_admin/templates/widgets/inputs/json.html
@@ -7,7 +7,7 @@
         {{ help_text }}
     </small>
 {% endif %}
-<input {% if not null %}required{% endif %} type="text" name="{{ name }}" value='{{ value|safe }}' hidden>
+<input {% if not null %}required{% endif %} type="text" name="{{ name }}" value='{{ value|tojson }}' hidden>
 <style>
     .jsoneditor {
         border: 1px solid #dadcde;


### PR DESCRIPTION
This fixes issues when the **JSON contains a single quote (`'`)** that could be converted into a double quote (`"`) and consequently **breaks the input tag's `value` attribute**. Using `tojson` ensures that the **value is escaped** before injecting it into the HTML input form. 